### PR TITLE
Fixed Error close-guide

### DIFF
--- a/archicad/communication.rkt
+++ b/archicad/communication.rkt
@@ -139,6 +139,17 @@
                                            #:py lst-y 
                                            #:pz lst-z) (connection-out (bim-connection)))))
 |#
+
+;;TODO rework conditions, too confusing...
+(define (close-guide points first-el [no-lists? #t])
+  (cond
+    [(and (null? points) no-lists?)(list first-el)]
+    [(null? points) (list)]
+    [(and (list? (car points)) no-lists?) (cons first-el (cons (append (car points) (list (caar points))) (close-guide (cdr points) first-el #f)))]
+    [(list? (car points))(cons (append (car points) (list (caar points))) (close-guide (cdr points) first-el #f))]
+    [else (cons (car points) (close-guide (cdr points) first-el no-lists?))]))
+
+
 (define (prepare-points-to-send lst)
   (let ((lst-x (list))
         (lst-y (list))

--- a/archicad/geometry.rkt
+++ b/archicad/geometry.rkt
@@ -71,11 +71,12 @@ the arc will be the opposite of the previous result.
                                   #:angle angle
                                   #:begang begang
                                   #:endang endang)))
-(define (line p0 p1)
+;Line is not used, instead we use a poly-lines for line
+#;(define (line p0 p1)
   (write-msg "Line" (linemsg* #:pts (prepare-points-to-send (list p0 p1))))
   (read-guid))
 
-(define (poly-line pts [arcs (list)])
+(define (line pts [arcs (list)])
   (write-msg "PolyLine" (polylinemsg* #:pts (prepare-points-to-send pts)
                                       #:arcs (prepare-arcs-to-send arcs)))
   (read-guid))
@@ -447,7 +448,7 @@ Example of usage: (hole-on-shell hpoints harcs hheight shellId)
 
 ;(send (polygon-points (list (xy -1 -1)(xy 1 -1)(xy 1 1)(xy -1 1))))
 ;Creates a polygon given points. Points aren't closed.
-(define (polygon points [material (default-morph-material)])
+(define (surface-polygon points [material (default-morph-material)])
   (let* ((sides (length points))
          (edges (polygon-edges sides))
          (polygon (internal-polygon sides)))


### PR DESCRIPTION
The communication.rkt was not updated in my last commit. It was missing close-guide. Now there should not be any errors.
