### PR TITLE
ArchiCAD Layers' Default

### DIFF
--- a/archicad/objects.rkt
+++ b/archicad/objects.rkt
@@ -78,7 +78,7 @@ Make the wall always double slanted whatever the angles?
               #:profile-name [profile-name ""]
               #:flipped? [flipped? #f]
               #:bottom-offset [bottom-offset 0]
-              #:layer [layer (default-layer)]
+              #:layer [layer "Structural Bearing"]
               #:windows [windows (list)]
               #:window-order [window-order (list)]
               #:reference-offset [reference-offset 0]
@@ -191,7 +191,7 @@ Make the wall always double slanted whatever the angles?
               #:profile-name [profile-name ""]
               #:flipped? [flipped? #f]
               #:bottom-offset [bottom-offset 0]
-              #:layer [layer (default-layer)]
+              #:layer [layer "Structural - Bearing"]
               #:windows [windows (list)]
               #:window-order [window-order (list)]
               #:reference-offset [reference-offset 0]
@@ -249,7 +249,7 @@ Example of usage:
               #:flip-x [flip-x #f]
               #:flip-y [flip-y #f]
               #:properties [properties (list)]
-              #:layer [layer (default-layer)])
+              #:layer [layer "Default Layer"])
   (let ((splitted-list (split-params-list properties)))
         (send/rcv-id "Door" (doormessage* #:guid guid
                                           #:objloc (cx p)
@@ -332,7 +332,7 @@ Example of usage:
                 #:flip-y [flip-y #f]
                 #:type-of-window [type-of-window "Window 18"]
                 #:properties [properties (list)]
-                #:layer [layer (default-layer)])
+                #:layer [layer "Default Layer"])
   (let ((splitted-list (split-params-list properties)))
     (send/rcv-id "Window" (windowmessage* #:guid guid
                                           #:objloc (cx p)
@@ -394,7 +394,7 @@ Example of usage:
                       #:bottom-level [bottom-level (current-level)]
                       #:top-level [top-level (upper-level bottom-level)]
                       #:offset [offset 0]
-                      #:layer [layer (default-layer)]
+                      #:layer [layer "Finish - Wall"]
                       #:height [height null]
                       #:main-panel-thickness [main-panel-thickness 0.2]
                       #:secondary-panel-thickness [secondary-panel-thickness 0.2]
@@ -530,7 +530,7 @@ Example of usage:
               #:material [material (cond [(eq? type-of-material "Basic") "GENERIC - INTERNAL CLADDING"]
                                          [(eq? type-of-material "Composite") "Generic Slab/Roof"])]
               #:parcs [parcs (list)]
-              #:layer [layer (default-layer)]
+              #:layer [layer "Structural - Bearing"]
               #:reference [reference (default-slab-reference)]
               ;#:sub-polygons [sub-polygons (list (length guide))]
               )
@@ -616,7 +616,7 @@ Example of usage:
                          #:thickness [thickness 0.3]
                          #:material [material (walls-from-slab-material-default)]
                          #:reference-line [reference-line (walls-from-slab-reference-line-default)]
-                         #:layer [layer (default-layer)])
+                         #:layer [layer "Structural - Bearing"])
   (internal-walls-from-slab slab-id height thickness material reference-line "BasicStructure" layer))
 
 #|
@@ -635,7 +635,7 @@ Example of usage:
                                    #:thickness [thickness 0.3]
                                    #:material [material (walls-from-slab-composite-material-default)]
                                    #:reference-line [reference-line (walls-from-slab-composite-reference-line-default)]
-                                   #:layer [layer (default-layer)])
+                                   #:layer [layer "Structural - Bearing"])
   (internal-walls-from-slab slab-id height thickness material reference-line "CompositeStructure" layer))
 
 #|HEIGHT NOT WORKING
@@ -679,7 +679,7 @@ Example of usage:
                 #:height [height null]
                 #:profile-name [profile-name ""]
                 #:bottom-offset [bottom-offset 0]
-                #:layer [layer (default-layer)])
+                #:layer [layer "Structural - Bearing"])
   (let ((msg (if (null? height)
                  (columnmsg*  #:posx (cx orig-pos)
                               #:posy (cy orig-pos)
@@ -723,7 +723,7 @@ Example of usage:
                 #:depth [depth 0.15]
                 #:width [width 0.15]
                 #:profile-name [profile-name ""]
-                #:layer [layer (default-layer)])
+                #:layer [layer "Structural - Bearing"])
   (let ((msg (columnmsg*  #:posx (cx p1)
                           #:posy (cy p1)
                           #:bottom (cz p1)
@@ -750,7 +750,7 @@ Example of usage:
                            #:width [width 0.15]
                            #:circle-based? [circle-based? #t]
                            #:material [material (columns-from-slab-material-default)]
-                           #:layer [layer (default-layer)])
+                           #:layer [layer "Structural - Bearing"])
   (let ((msg (columnsfromslab*  #:guid slab
                                 #:height height
                                 #:circlebased circle-based?
@@ -769,7 +769,7 @@ Example of usage:
               #:bottom-level [bottom-level (current-level)]
               #:material [material "GENERIC - STRUCTURAL"]
               #:profile [profile (default-beam-profile)]
-              #:layer [layer (default-layer)])
+              #:layer [layer "Structural - Bearing"])
   (let* ((new-p0 (loc-in-world p0))
          (new-p1 (loc-in-world p1))
          (msg (beammsg* #:x0 (cx new-p0)
@@ -925,7 +925,7 @@ Example of usage:
                 #:angle [angle 0]
                 #:height [height 0]
                 #:properties [properties (list)]
-                #:layer [layer (default-layer)])
+                #:layer [layer "Interior - Furniture"])
   (let* ((splitted-list (split-params-list properties))
          (msg (if (string? index/name)
                   (objectmsg* #:index 0
@@ -1000,7 +1000,7 @@ Function to create stairs
                 #:top-level [top-level (upper-level bottom-level)]
                 #:use-xy-fix-size [use-xy-fix-size #f]
                 #:properties [properties (list)]
-                #:layer [layer (default-layer)]
+                #:layer [layer "Structural - Combined"]
                 #:height [height 0]
                 ;Does NOT work because API does not support it
                 ;#:top-linked? [top-linked? (default-top-link)]
@@ -1102,7 +1102,7 @@ Example of usage:
               #:type-of-material [type-of-material (default-roof-type-of-material)]
               #:material [material (cond [(eq? type-of-material "Basic") "GENERIC - STRUCTURAL"]
                                          [(eq? type-of-material "Composite") "Generic Roof/Shell"])]
-              #:layer [layer (default-layer)])
+              #:layer [layer "Shell - Roof"])
   (let ((roof-info (prepare-points guide))
         (roof-msg (roofmsg* #:height height
                             #:material material
@@ -1149,7 +1149,7 @@ Function to create a poly roof
                    #:levels-angle [levels-angle (list)]
                    #:levels-height [levels-height (list)]
                    #:material [material (roof-material-default)]
-                   #:layer [layer (default-layer)])
+                   #:layer [layer "Shell - Roof"])
   (internal-poly-roof listpoints bottom-level height listarcs thickness levels-angle levels-height material "BasicStructure") layer)
 
 (define poly-roof-composite-material-default (make-parameter "Generic Roof/Shell"))
@@ -1162,7 +1162,7 @@ Function to create a poly roof
                              #:levels-angle [levels-angle (list)]
                              #:levels-height [levels-height (list)]
                              #:material [material (roof-composite-material-default)]
-                             #:layer [layer (default-layer)])
+                             #:layer [layer "Shell - Roof"])
   (internal-poly-roof listpoints bottom-level height listarcs thickness levels-angle levels-height material "CompositeStructure") layer)
 
 ;(send (poly-roof (list (list (xy 10 10)(xy 10 -10)(xy -10 -10)(xy -10 10)(xy 10 10))(list (xy 5 0)(xy -5 0)(xy 5 0))) 0 (list 0 0 0 0 0 pi pi)))
@@ -1184,7 +1184,7 @@ Function to create a poly roof
               #:material [material (default-mesh-material)]
               #:level-lines [level-lines (list)]
               #:override-material [override-material null]
-              #:layer [layer (default-layer)])
+              #:layer [layer "Site & Landscape - Terrain"])
   (let ((msg (if (null? override-material)
                       (meshmessage* #:level bottom
                                     #:material material


### PR DESCRIPTION
The default layers are now using the default used by archicad for each element.
Walls go for Structural - Bearing
Curtain Walls for Finish - Wall
These are two examples of the different layers.