### PR TITLE
ArchiCAD material defaults

### DIFF
--- a/archicad/objects.rkt
+++ b/archicad/objects.rkt
@@ -69,7 +69,7 @@ Make the wall always double slanted whatever the angles?
               #:type-of-material [type-of-material (default-wall-type-of-material)]
               #:material [material
                           #;(default-wall-material) 
-                          (cond [(eq? type-of-material "Basic") "GENERIC - STRUCTURAL"]
+                          (cond [(eq? type-of-material "Basic") "GENERIC - INTERNAL FILLER"]
                                 [(eq? type-of-material "Composite") "Generic Wall/Shell"])]
               #:alpha-angle [alpha-angle (/ pi 2)]
               #:beta-angle [beta-angle (/ pi 2)]
@@ -182,7 +182,7 @@ Make the wall always double slanted whatever the angles?
               #:type-of-material [type-of-material (default-wall-type-of-material)]
               #:material [material
                           #;(default-wall-material) 
-                          (cond [(eq? type-of-material "Basic") "GENERIC - STRUCTURAL"]
+                          (cond [(eq? type-of-material "Basic") "GENERIC - INTERNAL FILLER"]
                                 [(eq? type-of-material "Composite") "Generic Wall/Shell"])]
               #:alpha-angle [alpha-angle (/ pi 2)]
               #:beta-angle [beta-angle (/ pi 2)]
@@ -519,7 +519,7 @@ Example of usage:
 (define default-slab-reference (make-parameter "Top"))
 (define default-slab-type-of-material (make-parameter "Basic"))
 #;(define default-slab-material  
-    (make-parameter (cond [(eq? (default-slab-type-of-material) "Basic") "GENERIC - INTERNAL CLADDING"]
+    (make-parameter (cond [(eq? (default-slab-type-of-material) "Basic") "GENERIC - STRUCTURAL"]
                           [(eq? (default-slab-type-of-material) "Composite") "Generic Slab/Roof"])))
 (define (slab guide
               #:bottom-level [bottom-level (current-level)]
@@ -527,7 +527,7 @@ Example of usage:
               #:thickness [thickness 0.3]
               #:bottom [bottom 0]
               #:type-of-material [type-of-material (default-slab-type-of-material)]
-              #:material [material (cond [(eq? type-of-material "Basic") "GENERIC - INTERNAL CLADDING"]
+              #:material [material (cond [(eq? type-of-material "Basic") "GENERIC - STRUCTURAL"]
                                          [(eq? type-of-material "Composite") "Generic Slab/Roof"])]
               #:parcs [parcs (list)]
               #:layer [layer "Structural - Bearing"]
@@ -1100,7 +1100,7 @@ Example of usage:
               #:thickness [thickness 0.3]
               #:height [height 0]
               #:type-of-material [type-of-material (default-roof-type-of-material)]
-              #:material [material (cond [(eq? type-of-material "Basic") "GENERIC - STRUCTURAL"]
+              #:material [material (cond [(eq? type-of-material "Basic") "GENERIC - EXTERNAL FILLER"]
                                          [(eq? type-of-material "Composite") "Generic Roof/Shell"])]
               #:layer [layer "Shell - Roof"])
   (let ((roof-info (prepare-points guide))
@@ -1139,7 +1139,7 @@ Function to create a poly roof
     (read-material-guid)
     ))
 
-(define poly-roof-material-default (make-parameter "GENERIC - STRUCTURAL"))
+(define poly-roof-material-default (make-parameter "GENERIC - EXTERNAL FILLER"))
 (define roof-material-default (make-parameter "GENERIC - STRUCTURAL"))
 (define (poly-roof listpoints
                    #:bottom-level [bottom-level (current-level)]


### PR DESCRIPTION
Change the default material for ArchiCAD's elements. 
This was done to solve the intersection priority of the materials' properties.